### PR TITLE
MPOC-85-Add Patient Address Details

### DIFF
--- a/openmrs/i18n/registration/locale_en.json
+++ b/openmrs/i18n/registration/locale_en.json
@@ -32,5 +32,10 @@
   "district_locale":"District",
   "administrative_locale":"Administrative",
   "locality_locale":"Locality",
-  "REGISTRATION_EDUCATION_KEY":"Education Details"  
+  "ADDRESS_CLOSE_OF_LOCALE":"Close of",
+  "ADDRESS_AVENUE_STREET_LOCALE":"Avenue / Street",
+  "ADDRESS_BLOCK_LOCALE":"Block",
+  "ADDRESS_FLOOR_FLAT_LOCALE":"Floor / Flat",
+  "ADDRESS_HOUSE_NUMBER_LOCALE":"House Number",
+  "REGISTRATION_EDUCATION_KEY":"Education Details"
 }

--- a/openmrs/i18n/registration/locale_pt_BR.json
+++ b/openmrs/i18n/registration/locale_pt_BR.json
@@ -33,5 +33,10 @@
 	"district_locale":"Distrito",
 	"administrative_locale":"Administrativo",
 	"locality_locale":"Localidade",
-     "education":"Nivel de Escolaridade"
+    "education":"Nivel de Escolaridade",
+    "ADDRESS_CLOSE_OF_LOCALE":"Perto De",
+	"ADDRESS_AVENUE_STREET_LOCALE":"Avenida/Rua",
+	"ADDRESS_BLOCK_LOCALE":"Quateirão",
+	"ADDRESS_FLOOR_FLAT_LOCALE":"Andar / Flat",
+	"ADDRESS_HOUSE_NUMBER_LOCALE":"N^o^ da Casa"
 }		


### PR DESCRIPTION
MPOC-85-Add Patient Address Details

Following  Patient Address fields translation is added:

Avenida/Rua
Quarteirão
Andar/Flat 
N^o^ da Casa
Perto de

We should create Address level as follows in Openmrs Manage Address Hierarchy.
ADDRESS_CLOSE_OF_LOCALE
ADDRESS_AVENUE_STREET_LOCALE
ADDRESS_BLOCK_LOCALE
ADDRESS_FLOOR_FLAT_LOCALE
ADDRESS_HOUSE_NUMBER_LOCALE