### PR TITLE
MPOC-78-Remove fields from Registration Forms

### DIFF
--- a/openmrs/apps/registration/app.json
+++ b/openmrs/apps/registration/app.json
@@ -19,13 +19,6 @@
         "config" : {
                 "patientInformation": {
              	
-       "patientReferenceInformation": {
-                "title": "patientReferenceInformation",
-                "translationKey": "REGISTRATION_REFERENCE_INFO_KEY",
-                "attributes": ["Nome","Apelido","Phone_2"],
-                "order" : 2,
-                "expanded": true
-        },
         "patientTransferenceInformation": {
                 "title": "patientTransferenceInformation",
                 "translationKey": "REGISTRATION_TRANSFERENCE_INFO_KEY",
@@ -48,6 +41,7 @@
                 },
                 "defaults":  {
                     "class": "General",
+                    "TestResult": "HIV_Positive",
                     "landHolding": 2
                 }
             },
@@ -69,7 +63,7 @@
             "showLastName": true,
             "isLastNameMandatory": true,
             "showSaveConfirmDialog": false,
-            "showBirthTime": true,
+            "showBirthTime": false,
             "showCasteSameAsLastNameCheckbox": false,
             "printOptions": [
                 {


### PR DESCRIPTION
Removed Birth Time field from the Registration page.
For the person attribute "Resultado do Teste HIV" the result is kept default as "HIV Positive". Now the feature for keeping the "HIV Positive" uneditable is not available.
For removing Extra Identifier :
As tomorrow (28-02-2019) we have Demo, therefore, I have not removed following Identifiers from QA Server
CODIGO ATS/UATS,
CODIGO ITS
CODIGO PTV (MATERNIDADE)
CODIGO PTV (PRE-NATAL)
NID (CCR),
NIT (SECTOR DE TB)
NUMERO CANCRO CERVICAL
PCR (NUMERO DE REGISTRO)
I will remove these once Demo is done.