### PR TITLE
Amol | Hide the ability to capture the photo during patient registration

### DIFF
--- a/openmrs/apps/registration/app.json
+++ b/openmrs/apps/registration/app.json
@@ -64,6 +64,7 @@
             "isLastNameMandatory": true,
             "showSaveConfirmDialog": false,
             "showBirthTime": false,
+            "disablePhotoCapture": true,
             "showCasteSameAsLastNameCheckbox": false,
             "printOptions": [
                 {


### PR DESCRIPTION
Hided capture the photo from the Registration page.